### PR TITLE
feat: use next font

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Merriweather:wght@300;400;700;900&family=Lato:wght@300;400;700;900&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,16 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import { Merriweather, Lato } from 'next/font/google';
+
+const merriweather = Merriweather({
+  subsets: ['latin'],
+  weight: ['300', '400', '700', '900'],
+});
+
+const lato = Lato({
+  subsets: ['latin'],
+  weight: ['300', '400', '700', '900'],
+});
 
 export const metadata = {
   title: 'Carrillo Abogados',
@@ -9,7 +20,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="es">
-      <body>{children}</body>
+      <body className={`${merriweather.className} ${lato.className}`}>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- load Google fonts with next/font instead of CSS import
- apply Merriweather and Lato font classes in root layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_68bf6c116e54832199e557e7497e273e