### PR TITLE
fix: map hooks alias to lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -16,9 +20,18 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
+      "@/hooks/*": ["./lib/hooks/*"],
       "@/*": ["./*"]
-    }
+    },
+    "plugins": [
+      { "name": "next" }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- map `@/hooks/*` to `lib/hooks/*` for working imports

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bf70995e848321827f56a0b0600079