### PR TITLE
feat: validate Supabase env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Este repositorio contiene el código fuente del sitio web de la Asociación Carr
    npm install
    ```
 
+### Variables de entorno requeridas
+
+El proyecto necesita las siguientes variables para inicializar el cliente de Supabase:
+
+- `NEXT_PUBLIC_SUPABASE_URL`: URL de tu proyecto en Supabase.
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`: clave anónima pública de Supabase.
+
 ## Scripts
 
 - `npm run dev` – Ejecuta el servidor de desarrollo.

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,6 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+if (!supabaseUrl) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_URL is not defined');
+}
+
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+if (!supabaseAnonKey) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY is not defined');
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- guard against missing Supabase env vars
- document required Supabase variables

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68bf72ac035883218d2d04b814cf223b