### PR TITLE
chore: target ES2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## Summary
- target ES2017 in TypeScript config

## Testing
- `npm run build`
- `timeout 5 npm run start`
- `npx eslint .` *(fails: 219 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68bf74081dec8321a6c5d4f685aa7373