### PR TITLE
chore: enable unused-vars lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,6 @@ export default tseslint.config(
         "warn",
         { allowConstantExport: true },
       ],
-      "@typescript-eslint/no-unused-vars": "off",
     },
   }
 );


### PR DESCRIPTION
## Summary
- enable @typescript-eslint/no-unused-vars linting by removing the rule override

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npx eslint .` *(fails: _props, _, actionTypes unused)*

------
https://chatgpt.com/codex/tasks/task_e_68bf75baf74c8321963e87728c89cbdb